### PR TITLE
Removing trailing spaces from the dev / beta username lists

### DIFF
--- a/WME-Place-Harmonizer.js
+++ b/WME-Place-Harmonizer.js
@@ -251,8 +251,8 @@
                 var betaix = WMEPHuserList.indexOf('BETAUSERS');
                 WMEPHdevList = [];
                 WMEPHbetaList = [];
-                for (var ulix=1; ulix<betaix; ulix++) WMEPHdevList.push(WMEPHuserList[ulix].toLowerCase());
-                for (ulix=betaix+1; ulix<WMEPHuserList.length; ulix++) WMEPHbetaList.push(WMEPHuserList[ulix].toLowerCase());
+                for (var ulix=1; ulix<betaix; ulix++) WMEPHdevList.push(WMEPHuserList[ulix].toLowerCase().trim());
+                for (ulix=betaix+1; ulix<WMEPHuserList.length; ulix++) WMEPHbetaList.push(WMEPHuserList[ulix].toLowerCase().trim());
             });
         }, 100);
     }, betaDataDelay);


### PR DESCRIPTION
I was recently added to the beta users but my the spreadsheet has a trailing space. As such I don't match the beta check. This commit removes leading and trailing spaces from usernames before adding them to the lists.