### PR TITLE
Re-added 'plaLotTypeMissing'

### DIFF
--- a/WME-Place-Harmonizer.js
+++ b/WME-Place-Harmonizer.js
@@ -1899,7 +1899,9 @@
                         harmonizePlaceGo(item, 'harmonize');
                     }
                 },
-
+                plaLotTypeMissing: {
+                   active: false, severity: 3, message: 'Lot type: '
+                },
                 plaCostTypeMissing: {
                     active: false, severity: 1, message: 'Parking cost: '
                 },


### PR DESCRIPTION
'plaLotTypeMissing' was removed from the banner button which would cause WMEPH to not load when run on an unsaved PLA