### PR TITLE
Re-added 'plaLotTypeMissing' object

### DIFF
--- a/WME-Place-Harmonizer.js
+++ b/WME-Place-Harmonizer.js
@@ -1899,7 +1899,9 @@
                         harmonizePlaceGo(item, 'harmonize');
                     }
                 },
-
+                plaLotTypeMissing: {
+                   active: false, severity: 3, message: 'Lot type: '
+                },
                 plaCostTypeMissing: {
                     active: false, severity: 1, message: 'Parking cost: '
                 },


### PR DESCRIPTION
'plaLotTypeMissing' was recently removed from the banner buttons. The side effect was that WMEPH would fail to run on new, unsaved, PLAs. Adding it back resolves the issue. Issue exists in the currently deployed beta version