### PR TITLE
clonePlace & RemoveUncommonEVPaymentMethods bugfixes

### DIFF
--- a/WME-Place-Harmonizer.js
+++ b/WME-Place-Harmonizer.js
@@ -7783,7 +7783,7 @@ id="WMEPH-zipAltNameAdd"autocomplete="off" style="font-size:0.85em;width:65px;pa
                 updateItem = true;
             }
             if (updateItem) {
-                addUpdateAction(new UpdateObject(venue, cloneItems));
+                addUpdateAction(venue, cloneItems);
                 logDev('Venue details cloned');
             }
 

--- a/WME-Place-Harmonizer.js
+++ b/WME-Place-Harmonizer.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        WME Place Harmonizer
 // @namespace   WazeUSA
-// @version     2023.07.16.001
+// @version     2023.07.17.001
 // @description Harmonizes, formats, and locks a selected place
 // @author      WMEPH Development Group
 // @include     /^https:\/\/(www|beta)\.waze\.com\/(?!user\/)(.{2,6}\/)?editor\/?.*$/

--- a/WME-Place-Harmonizer.js
+++ b/WME-Place-Harmonizer.js
@@ -3683,7 +3683,7 @@
                 if (args.categories.includes(CAT.CHARGING_STATION) && !this.isWhitelisted(args)) {
                     const stationAttr = args.venue.attributes.categoryAttributes.CHARGING_STATION;
                     const network = stationAttr?.network;
-                    return !!(stationAttr?.paymentMethods?.some(method => !COMMON_EV_PAYMENT_METHODS[network]?.includes(method)));
+                    return COMMON_EV_PAYMENT_METHODS.hasOwnProperty(network) && !!(stationAttr?.paymentMethods?.some(method => !COMMON_EV_PAYMENT_METHODS[network]?.includes(method)));
                 }
                 return false;
             }
@@ -3703,7 +3703,7 @@
 
                 const commonPaymentMethods = COMMON_EV_PAYMENT_METHODS[network];
                 const newPaymentMethods = (stationAttr.paymentMethods?.slice() ?? [])
-                    .filter(method => commonPaymentMethods.includes(method));
+                    .filter(method => commonPaymentMethods?.includes(method));
 
                 const categoryAttrClone = JSON.parse(JSON.stringify(this.args.venue.getCategoryAttributes()));
                 categoryAttrClone.CHARGING_STATION ??= {};


### PR DESCRIPTION
Fixes the clonePlace() function. 

Checks if an EVCS network is defined in COMMON_EV_PAYMENT_METHODS before flagging a place with uncommon payment methods. Fixes an error that occurred if you tried to remove uncommon payment methods via the WMEPH banner if the network was not defined in COMMON_EV_PAYMENT_METHODS.